### PR TITLE
Added Arch linux target for npm via electron-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,32 @@
   "description": "PocketCaster App",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "postinstall": "install-app-deps",
+    "start": "electron .",
+    "pack": "build --dir",
+    "dist": "build"
+  },
+  "build": {
+    "appId": "PocketCaster",
+    "linux": {
+      "category": "Audio",
+      "maintainer": "Karl Lensson",
+      "vendor": "",
+      "executableName": "pocketcaster",
+      "synopsis": "An Electron-powered app for PocketCasts",
+      "description": "Tabs are so last year.",
+      "icon": "assets/icons/png/256x256.png",
+      "desktop": {
+        "Name": "PocketCaster",
+        "Exec": "pocketcaster",
+        "Icon": "256x256.png",
+        "Type": "Application",
+        "Categories": "Audio"
+      },
+      "target": [
+        "pacman"
+      ]
+    }
   },
   "repository": "https://github.com/jomurgel/PocketCasterApp",
   "keywords": [
@@ -13,9 +38,13 @@
     "podcast",
     "media"
   ],
-  "author": "jomurgel",
+  "author": {
+    "email": "hello@jomurgel.com",
+    "name": "jomurgel"
+  },
   "license": "CC0-1.0",
   "devDependencies": {
-    "electron": "^1.7.8"
+    "electron": "^1.7.8",
+    "electron-builder": "^20.26.1"
   }
 }


### PR DESCRIPTION
Build with 'npm run dist'. Run 'npm install' before doing so.